### PR TITLE
modify test since it actually has 2 winners

### DIFF
--- a/spec/04_game_spec.rb
+++ b/spec/04_game_spec.rb
@@ -110,7 +110,7 @@ describe 'Game' do
       game = Game.new
       game.board.cells = ["X", "O", "X",
                           "O", "O", "X",
-                          "O", "O", "X"]
+                          "O", "X", "X"]
 
       expect(game.won?).to contain_exactly(2, 5, 8)
     end


### PR DESCRIPTION
This test can be a little confusing for students when they work the project.  There are actually 2 winners the way the `board` is constructed, but really we should only have 1.  Depending on how the students have their `WINNING_COMBINATIONS` constant ordered, the `game.won?` may actually return `[1,4,7]` which is also technically correct.  

For clarity, it is best to have a single winner for this specific test.